### PR TITLE
remove tempobook from tsconfig exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     }
   },
   "include": ["src"],
-  "exclude": ["src/tempobook"],
+  "exclude": [],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Reason to remove is just cause if a user opens up vscode on their folder and looks at any of the tempobook files they'll see compile errors there.

Supposedly this was only there for build purposes but now we exclude tempobook through the gitignore anyway